### PR TITLE
Fix broken rowData contains all zero check

### DIFF
--- a/efficient_determinant.js
+++ b/efficient_determinant.js
@@ -26,7 +26,7 @@ class MatrixRow {
 			console.log(`Row ${candidateRow.toString()} was rejected for being equal to this row.`);
 			return false;
 		}
-		if(candidateRow.getRowData().reduce((accum, entry)=>entry==0)) {
+		if(candidateRow.getRowData().every((entry) => entry === 0)) {
 			console.log(`Row ${candidateRow.toString()} was rejected for being all zero.`);
 			return false;
 		}


### PR DESCRIPTION
The reduce() method runs a function on each array element, storing the return value of each iteration in the accumulator, and finally returns the accumulator value. If you never reference the accumulator value inside the function, then each iteration overwrites the previous result. The test as written was only actually checking whether the final dataRow value was zero.

Refactored to use the every() method which was designed for this exact use case.